### PR TITLE
feat: add copy URL button  to blocked page

### DIFF
--- a/src/blocked.html
+++ b/src/blocked.html
@@ -19,8 +19,14 @@
     </div>
     
     <div class="blocked-url-display">
-      Blocked URL: <span id="originalUrl"></span>
-    </div>
+      <span class="url-text">Blocked URL: <span id="originalUrl"></span></span>
+      <button id="copyUrlBtn" class="copy-btn" title="Copy URL">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+          <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+        </svg>
+      </button>
+    </div>    
         
     <p class="blocked-footer">To manage blocked sites, click the Focus Guard icon in your toolbar.</p>
   </div>

--- a/src/blocked.js
+++ b/src/blocked.js
@@ -1,11 +1,16 @@
 // Focus Guard Blocked Page Script
 // Shows when a blocked site is accessed
-import {images} from "./lib/core/images.js"
+import { images } from "./lib/core/images.js"
+
+let originalUrl = ""
 
 document.addEventListener("DOMContentLoaded", () => {
-  const originalUrl = document.getElementById("originalUrl")
+  const originalUrlElement = document.getElementById("originalUrl")
   const blockedImage = document.getElementById("blockedImage")
   const profileName = document.getElementById("profileName")
+  const copyUrlBtn = document.getElementById("copyUrlBtn")
+  const urlDisplay = document.querySelector(".blocked-url-display")
+  let originalUrlText = ""
 
   // Get URL and profile from query parameters
   const urlParams = new URLSearchParams(window.location.search)
@@ -13,7 +18,9 @@ document.addEventListener("DOMContentLoaded", () => {
   const profile = urlParams.get("profile")
 
   if (url) {
-    originalUrl.textContent = url
+    originalUrl = url
+    originalUrlElement.textContent = url
+    originalUrlText = url
   }
 
   if (profile) {
@@ -21,7 +28,45 @@ document.addEventListener("DOMContentLoaded", () => {
   }
 
   // Load custom image if set
-  images.loadImage().then(image => {
+  images.loadImage().then((image) => {
     blockedImage.src = image
   })
+
+  // Copy URL functionality
+  copyUrlBtn.addEventListener("click", async () => {
+    try {
+      await navigator.clipboard.writeText(originalUrlText)
+      showCopyFeedback(urlDisplay)
+    } catch (err) {
+      console.error("Failed to copy URL:", err)
+      // Show error feedback instead of fallback
+      showErrorFeedback(urlDisplay)
+    }
+  })
 })
+
+function showCopyFeedback(urlDisplay) {
+  const urlText = urlDisplay.querySelector(".url-text")
+  const originalText = urlText.innerHTML
+
+  // Show "Link Copied" feedback with green text only
+  urlText.innerHTML = '<span style="color: var(--primary);">Link Copied!</span>'
+
+  // Revert back after 1 second
+  setTimeout(() => {
+    urlText.innerHTML = originalText
+  }, 1000)
+}
+
+function showErrorFeedback(urlDisplay) {
+  const urlText = urlDisplay.querySelector(".url-text")
+  const originalText = urlText.innerHTML
+
+  // Show error feedback with red text
+  urlText.innerHTML = '<span style="color: var(--danger);">Copy failed!</span>'
+
+  // Revert back after 1 second
+  setTimeout(() => {
+    urlText.innerHTML = originalText
+  }, 1000)
+}

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -437,6 +437,41 @@ button:active {
   font-size: 14px;
   word-break: break-all;
   text-align: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  position: relative;
+}
+
+.url-text {
+  flex: 1;
+}
+
+.copy-btn {
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 6px;
+  cursor: pointer;
+  color: var(--text-light);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.2s;
+  min-width: 32px;
+  height: 32px;
+}
+
+.copy-btn:hover {
+  background: var(--primary);
+  color: white;
+  border-color: var(--primary);
+  transform: none;
+}
+
+.copy-btn:active {
+  transform: scale(0.95);
 }
 
 .blocked-footer {


### PR DESCRIPTION
| Normal View | When Copy URL is clicked | If Copy to Clipboard fails |
|--------|--------|--------|
| ![copy-url](https://github.com/user-attachments/assets/119d3c89-fb86-4911-a61b-653ac15fa1dc) | ![Screenshot 2025-05-30 at 12 26 35 PM](https://github.com/user-attachments/assets/0673bf74-6f63-431e-9aa8-d6ff0f38dc8a) | ![Screenshot 2025-05-30 at 12 30 04 PM](https://github.com/user-attachments/assets/9e1e619c-0884-40ed-a7f1-8bebdf5bd972) |
| **on hover** 
![Screenshot 2025-05-30 at 12 28 11 PM](https://github.com/user-attachments/assets/0c4c4f47-866f-4751-9ad1-003fee7721e8) | | |