### PR TITLE
Adjust the onbeforenavigate filter to properly sync changes

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -4,6 +4,7 @@ import { domains } from "./lib/core/domains.js"
 import { storage, webNavigation, runtime } from "./lib/browser/adapter.js"
 
 // Main extension code
+const scriptName = "background.js"
 let activeProfile = "default"
 let profilesData = {}
 
@@ -13,46 +14,56 @@ async function loadProfiles() {
   profilesData = loadedProfiles
   activeProfile = loadedActiveProfile || "default"
   
-  console.log("Loaded profiles:", profilesData)
-  console.log("Active profile:", activeProfile)
+  console.log(`[${scriptName}] Loaded profiles:`, profilesData)
+  console.log(`[${scriptName}] Active profile:`, activeProfile)
 }
 
 // Listen for storage changes
 storage.onChanged.addListener((changes) => {
   if (changes.profiles) {
     profilesData = changes.profiles.newValue
-    console.log("Updated profiles:", profilesData)
+    console.log(`[${scriptName}] Updated profiles:`, profilesData)
   }
 
   if (changes.activeProfile) {
     activeProfile = changes.activeProfile.newValue
-    console.log("Active profile changed to:", activeProfile)
+    console.log(`[${scriptName}] Active profile changed to:`, activeProfile)
   }
 })
 
+// Listen for navigation events
 webNavigation.onBeforeNavigate.addListener(
   async (details) => {
     // Whitelist tracking requests (only checks top-level URLs)
     if (requests.isTrackingRequest(details.url)) {
-      console.log("Allowing tracking request:", details.url)
+      console.log(`[${scriptName}] Allowing tracking request: ${details.url}`)
       return
     }
     
     // Block regular domains
     const url = new URL(details.url)
     if (await domains.isBlocked(url.hostname, activeProfile)) {
-      console.log("[Background] Blocking domain:", url.hostname)
+      console.log(`[${scriptName}] Blocking domain: ${url.hostname}`)
       const activeProfileName = profilesData[activeProfile]?.name || "Default"
       
-      webNavigation.tabs.update(details.tabId, {
+      let blocking = webNavigation.tabs.update(details.tabId, {
         url: runtime.getURL(
           `blocked.html?url=${encodeURIComponent(details.url)}&profile=${encodeURIComponent(activeProfileName)}`
         )
       })
+      blocking.then(onBlocked, onBlockError);
     }
   },
-  { url: [{ hostContains: "" }] },
+  { url: [{ schemes: ['http', 'https'] }] },
 )
+
+function onBlocked(tab) {
+  console.log(`[${scriptName}] Tab ${tab.id} updated to Block Page`)
+}
+
+function onBlockError(error) {
+  console.error(`[${scriptName}] Error updating tab [${error}] to Block Page`)
+}
 
 // Initialize
 loadProfiles()

--- a/src/content.js
+++ b/src/content.js
@@ -2,15 +2,17 @@ import { domains } from "./lib/core/domains.js"
 import {profiles} from "./lib/core/profiles.js"
 import {runtime} from "./lib/browser/adapter.js"
 
+const scriptName = "content.js"
+
 (async () => {
   try {
     const activeProfileId = await profiles.getActiveProfileId()
     const shouldBlock = await domains.isBlocked(window.location.hostname, activeProfileId)
     if (shouldBlock) {
-      console.log("[Content] Blocking domain:", window.location.hostname)
+      console.log(`[${scriptName}] Blocking domain: ${window.location.hostname}`)
       window.location.href = runtime.getURL('blocked.html');
     }
   } catch (error) {
-    console.error("Block check failed:", error)
+    console.error(`[${scriptName}] Block check failed:`, error)
   }
 })();

--- a/src/lib/browser/adapter.js
+++ b/src/lib/browser/adapter.js
@@ -24,8 +24,8 @@ export const storage = {
   },
   
   onChanged: isChrome
-    ? chrome.storage.onChanged
-    : browser.storage.onChanged
+    ? chrome.storage.sync.onChanged
+    : browser.storage.sync.onChanged
 }
 
 export const localStorage = {


### PR DESCRIPTION
- Use `storage.sync.onChange` instead of `storage.onChange`
- Filtering navigation events to catch only `http` and `https` requests. Ignoring `chrome://` and `about://`